### PR TITLE
修复：死亡掉落CommonRandomDrops为空时的空引用

### DIFF
--- a/AutoTeam/AutoTeamPlus.cs
+++ b/AutoTeam/AutoTeamPlus.cs
@@ -10,20 +10,10 @@ namespace autoteam
     public class Autoteam : TerrariaPlugin
     {
         public override string Author => "十七改，肝帝熙恩改";
-        public override Version Version => new Version(2, 3);
+        public override Version Version => new Version(2, 4);
         public override string Description => "自动队伍";
         public override string Name => "AutoTeamPlus";
         public static Configuration Config;
-
-        private readonly Dictionary<string, string> teamNames = new Dictionary<string, string>
-    {
-        { "none", "无队伍" },
-        { "red", "红队" },
-        { "green", "绿队" },
-        { "blue", "蓝队" },
-        { "yellow", "黄队" },
-        { "pink", "粉队" }
-    };
 
         public Autoteam(Main game) : base(game)
         {

--- a/DeathDrop/DeathDrop.cs
+++ b/DeathDrop/DeathDrop.cs
@@ -61,6 +61,10 @@ namespace DeathDrop
 
             if (Config.EnableRandomDrops)
             {
+                if (GetRandomItemIdFromGlobalConfig(Config) == 0)
+                {
+                    return;
+                }
                 int itemId = GetRandomItemIdFromGlobalConfig(Config);
 
                 if (Candorp(Config.RandomDropChance))
@@ -125,19 +129,26 @@ namespace DeathDrop
         {
             if (config.FullRandomDrops)
             {
-                int itemId = RandomGenerator.Next(1, 5453);
-
-                while (config.FullRandomExcludedItems.Contains(itemId))
+                int itemId;
+                do
                 {
                     itemId = RandomGenerator.Next(1, 5453);
-                }
+                } while (config.FullRandomExcludedItems.Contains(itemId));
 
                 return itemId;
             }
             else
             {
-                int randomIndex = RandomGenerator.Next(config.CommonRandomDrops.Count);
-                return config.CommonRandomDrops[randomIndex];
+                // 检查CommonRandomDrops列表是否非空
+                if (config.CommonRandomDrops.Count > 0)
+                {
+                    int randomIndex = RandomGenerator.Next(config.CommonRandomDrops.Count);
+                    return config.CommonRandomDrops[randomIndex];
+                }
+                else
+                {
+                    return 0;
+                }
             }
         }
 
@@ -156,8 +167,15 @@ namespace DeathDrop
             }
             else
             {
-                int randomIndex = RandomGenerator.Next(monster.CommonRandomDrops.Count);
+                if (monster.CommonRandomDrops.Count > 0)
+                {
+                    int randomIndex = RandomGenerator.Next(monster.CommonRandomDrops.Count);
                 return monster.CommonRandomDrops[randomIndex];
+                }
+                else
+                {
+                    return 0;
+                }
             }
         }
 


### PR DESCRIPTION
修复：死亡掉落CommonRandomDrops为空时的空引用
删了点autoteam的无用代码