### PR TITLE
添加插件：ProgressControl（计划书）

### DIFF
--- a/Plugin.sln
+++ b/Plugin.sln
@@ -172,8 +172,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnnouncementBoxPlus", "Anno
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleSql", "ConsoleSql\ConsoleSql.csproj", "{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProgressControl", "ProgressControl\ProgressControl.csproj", "{625563E6-33C6-4E38-A39E-31946A75E642}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Plugin.sln
+++ b/Plugin.sln
@@ -170,7 +170,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EndureBoost", "EndureBoost\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnnouncementBoxPlus", "AnnouncementBoxPlus\AnnouncementBoxPlus.csproj", "{BD2B4C70-4026-4355-AAB2-1622F7ACA0D8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleSql", "ConsoleSql\ConsoleSql.csproj", "{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleSql", "ConsoleSql\ConsoleSql.csproj", "{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProgressControl", "ProgressControl\ProgressControl.csproj", "{625563E6-33C6-4E38-A39E-31946A75E642}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -836,6 +838,14 @@ Global
 		{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}.Release|x64.ActiveCfg = Release|Any CPU
 		{E256745D-5ADA-4F89-886D-7FE3DAAAF6F5}.Release|x64.Build.0 = Release|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Debug|x64.Build.0 = Debug|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Release|Any CPU.Build.0 = Release|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Release|x64.ActiveCfg = Release|Any CPU
+		{625563E6-33C6-4E38-A39E-31946A75E642}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Plugins.json
+++ b/Plugins.json
@@ -1,4 +1,10 @@
-﻿[
+[
+  {
+    "Name": "ProgressControl",
+    "Version": "1.0.0.5",
+    "Author": "枳 羽学",
+    "Description": "计划书（自动化控制服务器）"
+  },
   {
     "Name": "Platform(判断玩家设备)",
     "Version": "1.1.0.0",
@@ -37,7 +43,7 @@
   },
   {
     "Name": "AutoTeamPlus",
-    "Version": "2.4",
+    "Version": "2.3",
     "Author": "十七改，肝帝熙恩改",
     "Description": "自动队伍"
   },

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@
 | [EndureBoost](EndureBoost/README.md)                             |      物品一定数量后长时间buff   |                                             无                                             |
 | [AnnouncementBoxPlus](AnnouncementBoxPlus/README.md)             |      广播盒功能强化             |                                             无                                             |
 | [ConsoleSql](ConsoleSql/README.md)                               |      允许你在控制台执行SQL语句   |                                             无                                             |
+| [ProgressControl](ProgressControl/README.md)                               |      计划书（自动化控制服务器）   |                                             无                                             |
 </Details>
 
 ## 代码贡献


### PR DESCRIPTION
更新日志
1.0.5
修复了Windows系统使用Bat脚本中goto start循环启动服务器时无法重置的问题
加入了/pco copy指令复制指定路径文件夹，并重命名源文件加上日期

1.0.4
适配了Linux系统与面板服的自动重置，
修复了用Bash脚本中while true;done循环启动服务器时无法重置的问题

1.0.3
加入了重置时删除指定文件，
加入了/pco delfile指令删除指定路径文件夹
根据击杀NPCID记数执行命令