### PR TITLE
fix(CaiBotLite): 修复ProgressControl错误显示已解锁的Boss

### DIFF
--- a/src/CaiBotLite/CaiBotLite.cs
+++ b/src/CaiBotLite/CaiBotLite.cs
@@ -13,7 +13,7 @@ namespace CaiBotLite;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class CaiBotLite(Main game) : TerrariaPlugin(game)
 {
-    public static readonly Version VersionNum = new (2026, 02, 25, 0);
+    public static readonly Version VersionNum = new (2026, 02, 25, 1);
     internal static int InitCode = -1;
     internal static bool DebugMode = Program.LaunchParameters.ContainsKey("-caidebug");
     private const string CharacterInfoKey = "CaiBotLite.CharacterInfo";

--- a/src/CaiBotLite/Common/ProgressControlSupport.cs
+++ b/src/CaiBotLite/Common/ProgressControlSupport.cs
@@ -61,7 +61,14 @@ public static class ProgressControlSupport
             {
                 continue;
             }
-            result[bossName] = TimeFormat(initDate + TimeSpan.FromHours(lockedBoss.Value));
+
+            var unlockTime = initDate + TimeSpan.FromHours(lockedBoss.Value);
+            if (unlockTime <= DateTime.Now)
+            {
+                continue;
+            }
+            
+            result[bossName] = TimeFormat(unlockTime);
         }
         
         return result;

--- a/src/CaiBotLite/README.md
+++ b/src/CaiBotLite/README.md
@@ -33,6 +33,10 @@ https://docs.terraria.ink/zh/caibot/CaiBotLite.html
 
 ## 更新日志
 
+### v2026.02.25.1
+
+- 修复ProgressControl错误显示已解锁的Boss
+
 ### v2026.02.25.0
 
 - 修复ProgressControl集成


### PR DESCRIPTION
### 更新插件/修复BUG
- [x] 插件已修改版本号
- [x] 更新插件README.md中的更新日志
- [x] 插件可以正常工作
### 其他
- [x] ❤️熙恩我喜欢你

## Summary by Sourcery

修复 ProgressControl 中错误的首领锁定显示，并更新插件版本及相关文档。

错误修复：
- 防止在 ProgressControl 中，将解锁时间已过的首领仍显示为已锁定。

文档：
- 在 README 中新增更新日志条目，记录 ProgressControl 首领锁定显示修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect boss lock display in ProgressControl and bump plugin version with documentation updates.

Bug Fixes:
- Prevent bosses whose unlock time has already passed from being listed as locked in ProgressControl.

Documentation:
- Add a changelog entry documenting the ProgressControl boss lock display fix in the README.

</details>

错误修复：
- 防止在 ProgressControl 中已解锁的 Boss 被错误显示为未解锁（锁定）。

文档：
- 在 README 的更新日志中加入此次错误修复版本的记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复 ProgressControl 中错误的首领锁定显示，并更新插件版本及相关文档。

错误修复：
- 防止在 ProgressControl 中，将解锁时间已过的首领仍显示为已锁定。

文档：
- 在 README 中新增更新日志条目，记录 ProgressControl 首领锁定显示修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect boss lock display in ProgressControl and bump plugin version with documentation updates.

Bug Fixes:
- Prevent bosses whose unlock time has already passed from being listed as locked in ProgressControl.

Documentation:
- Add a changelog entry documenting the ProgressControl boss lock display fix in the README.

</details>

</details>