### PR TITLE
Add CreateSpawn plugin to the collection

### DIFF
--- a/Plugin.slnx
+++ b/Plugin.slnx
@@ -147,4 +147,5 @@
   <Project Path="src/VotePlus/VotePlus.csproj" />
   <Project Path="src/WeaponPlus/WeaponPlus.csproj" />
   <Project Path="src/WikiLangPackLoader/WikiLangPackLoader.csproj" />
+  <Project Path="src/CreateSpawn/CreateSpawn.csproj" />
 </Solution>

--- a/src/CreateSpawn/Building.cs
+++ b/src/CreateSpawn/Building.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.GameContent.Tile_Entities;
+using TShockAPI;
+
+
+namespace CreateSpawn;
+
+public class Building
+{
+    public int Width { get; set; }
+    public int Height { get; set; }
+    public Tile[,]? Tiles { get; set; }
+    public Point Origin { get; set; }
+
+    public List<ChestItems>? ChestItems { get; set; }
+
+    public List<Sign>? Signs { get; set; }
+
+    public List<ItemFrames> ItemFrames { get; set; } = [];
+
+    public List<WeaponRack> WeaponsRacks { get; set; } = [];
+
+    public List<FPlatters> FoodPlatters { get; set; } = [];
+
+    public List<DDolls> DisplayDolls { get; set; } = [];
+
+    public List<HatRacks> HatRacks { get; set; } = [];
+
+    public List<LogicSensors> LogicSensors { get; set; } = [];
+}
+
+public class ChestItems
+{
+    public Item? Item { get; set; }
+    public Point Position { get; set; }
+    public int Slot { get; set; }
+}
+
+public class ItemFrames
+{
+    public NetItem Item { get; set; }
+    public Point Position { get; set; }
+}
+
+public class WeaponRack
+{
+    public NetItem Item { get; set; }
+    public Point Position { get; set; }
+}
+
+public class FPlatters
+{
+    public NetItem Item { get; set; }
+    public Point Position { get; set; }
+}
+
+public class DDolls
+{
+#nullable disable
+    public NetItem[] Items;
+    public NetItem[] Dyes;
+#nullable enable
+    public Point Position { get; set; }
+}
+
+public class HatRacks
+{
+    public NetItem[] Items { get; set; } = [];
+    public NetItem[] Dyes { get; set; } = [];
+    public Point Position { get; set; }
+}
+
+public class LogicSensors
+{
+    public Point Position { get; set; }
+    public TELogicSensor.LogicCheckType type { get; set; }
+}

--- a/src/CreateSpawn/Commands.cs
+++ b/src/CreateSpawn/Commands.cs
@@ -117,8 +117,10 @@ public class Commands
     }
 
     [Alias("auto")]
-    public static void AutoSpawn(CommandArgs args, string action, string? name = null)
+    [Flexible]
+    public static void AutoSpawn(CommandArgs args, string action)
     {
+        var name = args.Parameters.Count > 2 ? string.Join(" ", args.Parameters.Skip(2)) : null;
         action = action.ToLowerInvariant();
         var list = Config.Instance.AutoSpawnBuilds;
         switch (action)

--- a/src/CreateSpawn/Commands.cs
+++ b/src/CreateSpawn/Commands.cs
@@ -1,0 +1,223 @@
+﻿using LazyAPI.Attributes;
+using Microsoft.Xna.Framework;
+using TShockAPI;
+
+namespace CreateSpawn;
+
+[Command("cb")]
+[Permissions("create.build.copy")]
+public class Commands
+{
+    [Alias("spawn")]
+    public static void SpawnBuild(CommandArgs args, string name)
+    {
+        var ply = args.Player;
+        if (TileHelper.NeedWaitTask(ply))
+        {
+            return;
+        }
+
+        var clip = Map.LoadClip(name);
+        if (clip == null)
+        {
+            ply.SendErrorMessage(GetString("剪贴板为空或未找到指定建筑!"));
+            return;
+        }
+
+        var startX = 0;
+        var startY = 0;
+
+        if (ply.RealPlayer)
+        {
+            startX = ply.TileX - (clip.Width / 2);
+            startY = ply.TileY - clip.Height;
+        }
+        else
+        {
+            startX = Terraria.Main.spawnTileX - Config.Instance.CentreX + Config.Instance.AdjustX;
+            startY = Terraria.Main.spawnTileY - Config.Instance.CountY + Config.Instance.AdjustY;
+        }
+
+        Utils.SpawnBuilding(ply, startX, startY, clip);
+    }
+
+    [Alias("set")]
+    [RealPlayer]
+    public static void CopySet(CommandArgs args, int type)
+    {
+        switch (type)
+        {
+            case 1:
+                args.Player.AwaitingTempPoint = 1;
+                args.Player.SendInfoMessage(GetString("请选择复制区域的左上角"));
+                break;
+            case 2:
+                args.Player.AwaitingTempPoint = 2;
+                args.Player.SendInfoMessage(GetString("请选择复制区域的右下角"));
+                break;
+            default:
+                args.Player.SendInfoMessage(GetString($"正确指令：/cb set <1/2> --选择复制的区域"));
+                break;
+        }
+    }
+
+    [Alias("list")]
+    public static void BuildList(CommandArgs args)
+    {
+        var clipNames = Map.GetAllClipNames();
+
+        if (clipNames.Count == 0)
+        {
+            args.Player.SendErrorMessage(GetString("当前[c/64E0DA:没有可用]的复制建筑。"));
+            return;
+        }
+
+        args.Player.SendInfoMessage(GetString($"\n当前可用的复制建筑 [c/64E0DA:{clipNames.Count}个]:"));
+        for (var i = 0; i < clipNames.Count; i++)
+        {
+            var msg = $"[c/D0AFEB:{i + 1}.] [c/FFFFFF:{clipNames[i]}]";
+            args.Player.SendMessage(msg, Color.AntiqueWhite);
+        }
+
+        args.Player.SendInfoMessage(GetString($"可使用指定粘贴指令:[c/D0AFEB:/cb spawn 名字]"));
+    }
+
+    [Alias("save")]
+    [RealPlayer]
+    public static void CopyBuilding(CommandArgs args, string name)
+    {
+        var plr = args.Player;
+        if (plr.TempPoints[0].X == 0 || plr.TempPoints[1].X == 0)
+        {
+            plr.SendInfoMessage(GetString("您还没有选择区域！"));
+            plr.SendMessage(GetString("使用方法: /cb set 1 选择左上角"), Color.AntiqueWhite);
+            plr.SendMessage(GetString("使用方法: /cb set 2 选择右下角"), Color.AntiqueWhite);
+            return;
+        }
+
+        var clip = Utils.CopyBuilding(
+            plr.TempPoints[0].X, plr.TempPoints[0].Y,
+            plr.TempPoints[1].X, plr.TempPoints[1].Y);
+        Map.SaveClip(name, clip);
+        plr.SendSuccessMessage(GetString($"已复制区域 ({clip.Width}x{clip.Height})"));
+    }
+
+    [Alias("back")]
+    [RealPlayer]
+    public static void BackBuilding(CommandArgs args)
+    {
+        Utils.Restore(args.Player);
+    }
+
+    [Alias("zip")]
+    public static void BackupAndDeleteAllDataFiles(CommandArgs args)
+    {
+        Map.BackupAndDeleteAllDataFiles();
+        args.Player.SendSuccessMessage(GetString("已备份并清空所有建筑数据文件。"));
+    }
+
+    [Alias("auto")]
+    public static void AutoSpawn(CommandArgs args, string action, string? name = null)
+    {
+        action = action.ToLowerInvariant();
+        var list = Config.Instance.AutoSpawnBuilds;
+        switch (action)
+        {
+            case "add":
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    args.Player.SendErrorMessage(GetString("用法: /cb auto add <建筑名>"));
+                    return;
+                }
+
+                if (list.Any(x => x.Equals(name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    args.Player.SendInfoMessage(GetString($"建筑 {name} 已在自动生成列表中。"));
+                    return;
+                }
+
+                if (Map.LoadClip(name) == null)
+                {
+                    args.Player.SendErrorMessage(GetString($"未找到建筑: {name}"));
+                    return;
+                }
+
+                list.Add(name);
+                Config.Save();
+                args.Player.SendSuccessMessage(GetString($"已添加自动生成建筑: {name}"));
+                break;
+
+            case "remove":
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    args.Player.SendErrorMessage(GetString("用法: /cb auto remove <建筑名>"));
+                    return;
+                }
+
+                var removed = list.RemoveAll(x => x.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (removed == 0)
+                {
+                    args.Player.SendInfoMessage(GetString($"自动生成列表中不存在: {name}"));
+                    return;
+                }
+
+                Config.Save();
+                args.Player.SendSuccessMessage(GetString($"已移除自动生成建筑: {name}"));
+                break;
+
+            case "list":
+                if (list.Count == 0)
+                {
+                    args.Player.SendInfoMessage(GetString("自动生成建筑列表为空。"));
+                    return;
+                }
+
+                args.Player.SendInfoMessage(GetString($"自动生成建筑列表 ({list.Count})："));
+                foreach (var build in list)
+                {
+                    args.Player.SendInfoMessage($"- {build}");
+                }
+
+                break;
+
+            case "clear":
+                list.Clear();
+                Config.Save();
+                args.Player.SendSuccessMessage(GetString("已清空自动生成建筑列表。"));
+                break;
+
+            default:
+                args.Player.SendInfoMessage(GetString("用法: /cb auto <add/remove/list/clear> [建筑名]"));
+                break;
+        }
+    }
+
+    [Alias("help")]
+    public static void HelpCmd(CommandArgs args)
+    {
+        var random = new Random();
+        var color = RandomColors(random);
+
+        args.Player.SendInfoMessage(GetString($"复制建筑指令菜单"));
+        args.Player.SendMessage(GetString($"/cb set 1 ——敲击或放置一个方块到左上角"), color);
+        args.Player.SendMessage(GetString($"/cb set 2 ——敲击或放置一个方块到右下角"), color);
+        args.Player.SendMessage(GetString($"/cb save 名字 ——添加建筑"), color);
+        args.Player.SendMessage(GetString($"/cb spawn 名字 ——生成建筑"), color);
+        args.Player.SendMessage(GetString($"/cb back ——还原图格"), color);
+        args.Player.SendMessage(GetString($"/cb list —-文件列表"), color);
+        args.Player.SendMessage(GetString($"/cb zip ——清空建筑并备份为zip"), color);
+        args.Player.SendMessage(GetString($"/cb auto add 名字 ——加入新世界自动生成列表"), color);
+        args.Player.SendMessage(GetString($"/cb auto remove 名字 ——移除自动生成列表"), color);
+        args.Player.SendMessage(GetString($"/cb auto list ——查看自动生成列表"), color);
+        args.Player.SendMessage(GetString($"/cb auto clear ——清空自动生成列表"), color);
+    }
+
+    private static Color RandomColors(Random random)
+    {
+        var r = random.Next(150, 200);
+        var g = random.Next(170, 200);
+        var b = random.Next(170, 200);
+        var color = new Color(r, g, b);
+        return color;
+    }
+}

--- a/src/CreateSpawn/Config.cs
+++ b/src/CreateSpawn/Config.cs
@@ -1,0 +1,39 @@
+﻿using LazyAPI.Attributes;
+using LazyAPI.ConfigFiles;
+
+namespace CreateSpawn;
+
+[Config]
+public class Config : JsonConfigBase<Config>
+{
+    protected override string Filename => "CreateSpawn";
+
+    [LocalizedPropertyName(CultureType.Chinese, "中心X")]
+    [LocalizedPropertyName(CultureType.English, "CentreX")]
+    public int CentreX { get; set; } = 0;
+
+    [LocalizedPropertyName(CultureType.Chinese, "计数Y")]
+    [LocalizedPropertyName(CultureType.English, "CountY")]
+    public int CountY { get; set; } = 0;
+
+    [LocalizedPropertyName(CultureType.Chinese, "微调X")]
+    [LocalizedPropertyName(CultureType.English, "AdjustX")]
+    public int AdjustX { get; set; } = 0;
+
+    [LocalizedPropertyName(CultureType.Chinese, "微调Y")]
+    [LocalizedPropertyName(CultureType.English, "AdjustY")]
+    public int AdjustY { get; set; } = 0;
+
+    [LocalizedPropertyName(CultureType.Chinese, "自动生成建筑")]
+    [LocalizedPropertyName(CultureType.English, "AutoSpawnBuilds")]
+    public List<string> AutoSpawnBuilds { get; set; } = [];
+
+    protected override void SetDefault()
+    {
+        this.CentreX = 0;
+        this.CountY = 0;
+        this.AdjustX = 0;
+        this.AdjustY = 0;
+        this.AutoSpawnBuilds = [];
+    }
+}

--- a/src/CreateSpawn/CreateSpawn.csproj
+++ b/src/CreateSpawn/CreateSpawn.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\..\template.targets"/>
+
+    <ItemGroup>
+        <ProjectReference Include="..\LazyAPI\LazyAPI.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/src/CreateSpawn/Map.cs
+++ b/src/CreateSpawn/Map.cs
@@ -1,0 +1,513 @@
+﻿using Microsoft.Xna.Framework;
+using System.IO.Compression;
+using Terraria;
+using Terraria.GameContent.Tile_Entities;
+using TShockAPI;
+
+namespace CreateSpawn;
+
+public class Map
+{
+    internal static readonly string Paths = Path.Combine(TShock.SavePath, "CreateSpawn");
+
+    private static GZipStream GZipWrite(string filePath)
+    {
+        var fileStream = new FileStream(filePath, FileMode.Create);
+        return new GZipStream(fileStream, CompressionLevel.Optimal);
+    }
+
+    private static GZipStream GZipRead(string filePath)
+    {
+        var fileStream = new FileStream(filePath, FileMode.Open);
+        return new GZipStream(fileStream, CompressionMode.Decompress);
+    }
+
+
+    public static Stack<Building> LoadBack(string name)
+    {
+        var filePath = Path.Combine(Paths, $"{name}_bk.map");
+        if (!File.Exists(filePath))
+        {
+            return new Stack<Building>();
+        }
+
+        var stack = new Stack<Building>();
+        using (var fs = GZipRead(filePath))
+        using (var reader = new BinaryReader(fs))
+        {
+            var count = reader.ReadInt32();
+            for (var i = 0; i < count; i++)
+            {
+                stack.Push(LoadBuilding(reader));
+            }
+        }
+
+        return stack;
+    }
+
+
+    public static void SaveBack(string name, Stack<Building> stack)
+    {
+        Directory.CreateDirectory(Paths);
+        var filePath = Path.Combine(Paths, $"{name}_bk.map");
+
+        using (var fs = GZipWrite(filePath))
+        using (var writer = new BinaryWriter(fs))
+        {
+            writer.Write(stack.Count);
+            foreach (var building in stack)
+            {
+                SaveBuilding(writer, building);
+            }
+        }
+    }
+
+    internal static Building LoadClip(string name)
+    {
+        var filePath = Path.Combine(Paths, $"{name}_cp.map");
+        if (!File.Exists(filePath))
+        {
+            return null!;
+        }
+
+        using var fs = GZipRead(filePath);
+        using var reader = new BinaryReader(fs);
+        return LoadBuilding(reader);
+    }
+
+    internal static void SaveClip(string name, Building building)
+    {
+        Directory.CreateDirectory(Paths);
+        var filePath = Path.Combine(Paths, $"{name}_cp.map");
+
+        using (var fs = GZipWrite(filePath))
+        using (var writer = new BinaryWriter(fs))
+        {
+            SaveBuilding(writer, building);
+        }
+    }
+
+    private static void SaveBuilding(BinaryWriter writer, Building clip)
+    {
+        writer.Write(clip.Origin.X);
+        writer.Write(clip.Origin.Y);
+        writer.Write(clip.Width);
+        writer.Write(clip.Height);
+
+        if (clip.Tiles == null)
+        {
+            return;
+        }
+
+        for (var x = 0; x < clip.Width; x++)
+        {
+            for (var y = 0; y < clip.Height; y++)
+            {
+                var tile = clip.Tiles[x, y];
+                writer.Write(tile.bTileHeader);
+                writer.Write(tile.bTileHeader2);
+                writer.Write(tile.bTileHeader3);
+                writer.Write(tile.frameX);
+                writer.Write(tile.frameY);
+                writer.Write(tile.liquid);
+                writer.Write(tile.sTileHeader);
+                writer.Write(tile.type);
+                writer.Write(tile.wall);
+            }
+        }
+
+        writer.Write(clip.ChestItems?.Count ?? 0);
+        if (clip.ChestItems != null)
+        {
+            foreach (var data in clip.ChestItems)
+            {
+                writer.Write(data.Position.X);
+                writer.Write(data.Position.Y);
+                writer.Write(data.Slot);
+                writer.Write(data.Item?.type ?? 0);
+                writer.Write(data.Item?.type ?? 0);
+                writer.Write(data.Item?.stack ?? 0);
+                writer.Write(data.Item?.prefix ?? 0);
+            }
+        }
+
+        writer.Write(clip.Signs?.Count ?? 0);
+        if (clip.Signs != null)
+        {
+            foreach (var sign in clip.Signs)
+            {
+                writer.Write(sign.x - clip.Origin.X); // 相对坐标
+                writer.Write(sign.y - clip.Origin.Y);
+                writer.Write(sign.text ?? "");
+            }
+        }
+
+        writer.Write(clip.ItemFrames?.Count ?? 0);
+        if (clip.ItemFrames != null)
+        {
+            foreach (var data in clip.ItemFrames)
+            {
+                writer.Write(data.Position.X - clip.Origin.X); // 存储相对坐标
+                writer.Write(data.Position.Y - clip.Origin.Y);
+                writer.Write(data.Item.NetId);
+                writer.Write(data.Item.Stack);
+                writer.Write(data.Item.PrefixId);
+            }
+        }
+
+        writer.Write(clip.WeaponsRacks?.Count ?? 0);
+        if (clip.WeaponsRacks != null)
+        {
+            foreach (var data in clip.WeaponsRacks)
+            {
+                writer.Write(data.Position.X - clip.Origin.X);
+                writer.Write(data.Position.Y - clip.Origin.Y);
+                writer.Write(data.Item.NetId);
+                writer.Write(data.Item.Stack);
+                writer.Write(data.Item.PrefixId);
+            }
+        }
+
+        writer.Write(clip.FoodPlatters?.Count ?? 0);
+        if (clip.FoodPlatters != null)
+        {
+            foreach (var data in clip.FoodPlatters)
+            {
+                writer.Write(data.Position.X - clip.Origin.X);
+                writer.Write(data.Position.Y - clip.Origin.Y);
+                writer.Write(data.Item.NetId);
+                writer.Write(data.Item.Stack);
+                writer.Write(data.Item.PrefixId);
+            }
+        }
+
+        writer.Write(clip.DisplayDolls?.Count ?? 0);
+        if (clip.DisplayDolls != null)
+        {
+            foreach (var doll in clip.DisplayDolls)
+            {
+                // 保存相对坐标
+                writer.Write(doll.Position.X - clip.Origin.X);
+                writer.Write(doll.Position.Y - clip.Origin.Y);
+
+                // 保存物品数据 (8个槽位)
+                writer.Write(doll.Items.Length);
+                foreach (var item in doll.Items)
+                {
+                    writer.Write(item.NetId);
+                    writer.Write(item.Stack);
+                    writer.Write(item.PrefixId);
+                }
+
+                // 保存染料数据 (8个槽位)
+                writer.Write(doll.Dyes.Length);
+                foreach (var dye in doll.Dyes)
+                {
+                    writer.Write(dye.NetId);
+                    writer.Write(dye.Stack);
+                    writer.Write(dye.PrefixId);
+                }
+            }
+        }
+
+        writer.Write(clip.HatRacks?.Count ?? 0);
+        if (clip.HatRacks != null)
+        {
+            foreach (var Rack in clip.HatRacks)
+            {
+                // 保存相对坐标
+                writer.Write(Rack.Position.X - clip.Origin.X);
+                writer.Write(Rack.Position.Y - clip.Origin.Y);
+
+                // 保存物品数据 (2个槽位)
+                writer.Write(Rack.Items.Length);
+                foreach (var item in Rack.Items)
+                {
+                    writer.Write(item.NetId);
+                    writer.Write(item.Stack);
+                    writer.Write(item.PrefixId);
+                }
+
+                // 保存染料数据 (2个槽位)
+                writer.Write(Rack.Dyes.Length);
+                foreach (var dye in Rack.Dyes)
+                {
+                    writer.Write(dye.NetId);
+                    writer.Write(dye.Stack);
+                    writer.Write(dye.PrefixId);
+                }
+            }
+        }
+
+        writer.Write(clip.LogicSensors?.Count ?? 0);
+        if (clip.LogicSensors != null)
+        {
+            foreach (var data in clip.LogicSensors)
+            {
+                writer.Write(data.Position.X - clip.Origin.X);
+                writer.Write(data.Position.Y - clip.Origin.Y);
+                writer.Write((int) data.type);
+            }
+        }
+    }
+
+    private static Building LoadBuilding(BinaryReader reader)
+    {
+        var originX = reader.ReadInt32();
+        var originY = reader.ReadInt32();
+        var width = reader.ReadInt32();
+        var height = reader.ReadInt32();
+
+        var tiles = new Tile[width, height];
+        for (var x = 0; x < width; x++)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var tile = new Tile
+                {
+                    bTileHeader = reader.ReadByte(),
+                    bTileHeader2 = reader.ReadByte(),
+                    bTileHeader3 = reader.ReadByte(),
+                    frameX = reader.ReadInt16(),
+                    frameY = reader.ReadInt16(),
+                    liquid = reader.ReadByte(),
+                    sTileHeader = reader.ReadUInt16(),
+                    type = reader.ReadUInt16(),
+                    wall = reader.ReadUInt16()
+                };
+                tiles[x, y] = tile;
+            }
+        }
+
+        var chestItemCount = reader.ReadInt32();
+        var chestItems = new List<ChestItems>(chestItemCount);
+        for (var i = 0; i < chestItemCount; i++)
+        {
+            var posX = reader.ReadInt32();
+            var posY = reader.ReadInt32();
+            var slot = reader.ReadInt32();
+            var type = reader.ReadInt32();
+            var netId = reader.ReadInt32();
+            var stack = reader.ReadInt32();
+            var prefix = reader.ReadByte();
+
+            var item = new Item();
+            item.SetDefaults(type);
+            item.type = netId;
+            item.stack = stack;
+            item.prefix = prefix;
+
+            chestItems.Add(new ChestItems { Position = new Point(posX, posY), Slot = slot, Item = item });
+        }
+
+        var signCount = reader.ReadInt32();
+        var signs = new List<Sign>(signCount);
+        for (var i = 0; i < signCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+            var text = reader.ReadString();
+
+            signs.Add(new Sign { x = originX + relX, y = originY + relY, text = text });
+        }
+
+        var itemFrameCount = reader.ReadInt32();
+        var itemFrames = new List<ItemFrames>(itemFrameCount);
+        for (var i = 0; i < itemFrameCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+            var netId = reader.ReadInt32();
+            var stack = reader.ReadInt32();
+            var prefix = reader.ReadByte();
+
+            itemFrames.Add(new ItemFrames { Position = new Point(originX + relX, originY + relY), Item = new NetItem(netId, stack, prefix) });
+        }
+
+        var weaponRackCount = reader.ReadInt32();
+        var weaponRacks = new List<WeaponRack>(weaponRackCount);
+        for (var i = 0; i < weaponRackCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+            var netId = reader.ReadInt32();
+            var stack = reader.ReadInt32();
+            var prefix = reader.ReadByte();
+
+            weaponRacks.Add(new WeaponRack { Position = new Point(originX + relX, originY + relY), Item = new NetItem(netId, stack, prefix) });
+        }
+
+        var foodPlatterCount = reader.ReadInt32();
+        var foodPlatters = new List<FPlatters>(foodPlatterCount);
+        for (var i = 0; i < foodPlatterCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+            var netId = reader.ReadInt32();
+            var stack = reader.ReadInt32();
+            var prefix = reader.ReadByte();
+
+            foodPlatters.Add(new FPlatters { Position = new Point(originX + relX, originY + relY), Item = new NetItem(netId, stack, prefix) });
+        }
+
+        var dollCount = reader.ReadInt32();
+        var displayDolls = new List<DDolls>(dollCount);
+        for (var i = 0; i < dollCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+
+            // 读取物品
+            var itemCount = reader.ReadInt32();
+            var items = new NetItem[itemCount];
+            for (var j = 0; j < itemCount; j++)
+            {
+                items[j] = new NetItem(
+                    reader.ReadInt32(),
+                    reader.ReadInt32(),
+                    reader.ReadByte()
+                );
+            }
+
+            // 读取染料
+            var dyeCount = reader.ReadInt32();
+            var dyes = new NetItem[dyeCount];
+            for (var j = 0; j < dyeCount; j++)
+            {
+                dyes[j] = new NetItem(
+                    reader.ReadInt32(),
+                    reader.ReadInt32(),
+                    reader.ReadByte()
+                );
+            }
+
+            displayDolls.Add(new DDolls { Position = new Point(originX + relX, originY + relY), Items = items, Dyes = dyes });
+        }
+
+        var RackCount = reader.ReadInt32();
+        var hatRacks = new List<HatRacks>(RackCount);
+        for (var i = 0; i < RackCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+
+            // 读取物品
+            var itemCount = reader.ReadInt32();
+            var items = new NetItem[itemCount];
+            for (var j = 0; j < itemCount; j++)
+            {
+                items[j] = new NetItem(
+                    reader.ReadInt32(),
+                    reader.ReadInt32(),
+                    reader.ReadByte()
+                );
+            }
+
+            // 读取染料
+            var dyeCount = reader.ReadInt32();
+            var dyes = new NetItem[dyeCount];
+            for (var j = 0; j < dyeCount; j++)
+            {
+                dyes[j] = new NetItem(
+                    reader.ReadInt32(),
+                    reader.ReadInt32(),
+                    reader.ReadByte()
+                );
+            }
+
+            hatRacks.Add(new HatRacks { Position = new Point(originX + relX, originY + relY), Items = items, Dyes = dyes });
+        }
+
+        var LogicSensorsCount = reader.ReadInt32();
+        var logicSensors = new List<LogicSensors>(LogicSensorsCount);
+        for (var i = 0; i < LogicSensorsCount; i++)
+        {
+            var relX = reader.ReadInt32();
+            var relY = reader.ReadInt32();
+            var type = reader.ReadInt32();
+
+            logicSensors.Add(new LogicSensors { Position = new Point(originX + relX, originY + relY), type = (TELogicSensor.LogicCheckType) type });
+        }
+
+        return new Building
+        {
+            Origin = new Point(originX, originY),
+            Width = width,
+            Height = height,
+            Tiles = tiles,
+            ChestItems = chestItems,
+            Signs = signs,
+            ItemFrames = itemFrames,
+            WeaponsRacks = weaponRacks,
+            FoodPlatters = foodPlatters,
+            DisplayDolls = displayDolls,
+            HatRacks = hatRacks,
+            LogicSensors = logicSensors
+        };
+    }
+
+    public static List<string> GetAllClipNames()
+    {
+        if (!Directory.Exists(Paths))
+        {
+            return new List<string>();
+        }
+
+        return Directory.GetFiles(Paths, "*_cp.map")
+            .Select(f => Path.GetFileNameWithoutExtension(f).Replace("_cp", ""))
+            .ToList();
+    }
+
+    public static void BackupAndDeleteAllDataFiles()
+    {
+        if (!Directory.Exists(Paths))
+        {
+            return;
+        }
+
+        // 构建压缩包保存路径
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
+        var backupFolder = Path.Combine(Paths, $"{timestamp}");
+        var zipFilePath = Path.Combine(Paths, $"{timestamp}.zip");
+
+        try
+        {
+            // 创建临时备份文件夹
+            Directory.CreateDirectory(backupFolder);
+
+            // 将所有 .dat 文件复制到备份文件夹
+            foreach (var file in Directory.GetFiles(Paths, "*_cp.map"))
+            {
+                var destFile = Path.Combine(backupFolder, Path.GetFileName(file));
+                File.Copy(file, destFile, true);
+            }
+
+            // 压缩文件夹为 .zip
+            ZipFile.CreateFromDirectory(backupFolder, zipFilePath, CompressionLevel.SmallestSize, false);
+
+            // 删除临时文件夹（不再需要了）
+            Directory.Delete(backupFolder, true);
+
+            TShock.Log.ConsoleInfo(GetString($"已成功备份所有 .map 文件，压缩包保存于:\n {zipFilePath}"));
+
+            // 删除原始 .dat 文件
+            foreach (var file in Directory.GetFiles(Paths, "*.map"))
+            {
+                try
+                {
+                    File.Delete(file);
+                }
+                catch (Exception ex)
+                {
+                    TShock.Log.ConsoleInfo(GetString($"删除文件失败: {file}, 错误: {ex.Message}"));
+                }
+            }
+
+            TShock.Log.ConsoleInfo(GetString($"已成功删除所有 .map 文件"));
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.ConsoleInfo(GetString($"备份和删除过程中出错: {ex.Message}"));
+        }
+    }
+}

--- a/src/CreateSpawn/Map.cs
+++ b/src/CreateSpawn/Map.cs
@@ -32,14 +32,27 @@ public class Map
         }
 
         var stack = new Stack<Building>();
-        using (var fs = GZipRead(filePath))
-        using (var reader = new BinaryReader(fs))
+        try
         {
+            using var fs = GZipRead(filePath);
+            using var reader = new BinaryReader(fs);
             var count = reader.ReadInt32();
+
+            var list = new List<Building>(count);
             for (var i = 0; i < count; i++)
             {
-                stack.Push(LoadBuilding(reader));
+                list.Add(LoadBuilding(reader));
             }
+
+            for (var i = list.Count - 1; i >= 0; i--)
+            {
+                stack.Push(list[i]);
+            }
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.ConsoleWarn(GetString($"读取撤销记录失败: {ex.Message}"));
+            return new Stack<Building>();
         }
 
         return stack;
@@ -124,7 +137,6 @@ public class Map
                 writer.Write(data.Position.X);
                 writer.Write(data.Position.Y);
                 writer.Write(data.Slot);
-                writer.Write(data.Item?.type ?? 0);
                 writer.Write(data.Item?.type ?? 0);
                 writer.Write(data.Item?.stack ?? 0);
                 writer.Write(data.Item?.prefix ?? 0);
@@ -287,13 +299,11 @@ public class Map
             var posY = reader.ReadInt32();
             var slot = reader.ReadInt32();
             var type = reader.ReadInt32();
-            var netId = reader.ReadInt32();
             var stack = reader.ReadInt32();
             var prefix = reader.ReadByte();
 
             var item = new Item();
             item.SetDefaults(type);
-            item.type = netId;
             item.stack = stack;
             item.prefix = prefix;
 
@@ -475,7 +485,7 @@ public class Map
             // 创建临时备份文件夹
             Directory.CreateDirectory(backupFolder);
 
-            // 将所有 .dat 文件复制到备份文件夹
+            // 将所有 .map 文件复制到备份文件夹
             foreach (var file in Directory.GetFiles(Paths, "*_cp.map"))
             {
                 var destFile = Path.Combine(backupFolder, Path.GetFileName(file));
@@ -490,7 +500,7 @@ public class Map
 
             TShock.Log.ConsoleInfo(GetString($"已成功备份所有 .map 文件，压缩包保存于:\n {zipFilePath}"));
 
-            // 删除原始 .dat 文件
+            // 删除原始 .map 文件
             foreach (var file in Directory.GetFiles(Paths, "*.map"))
             {
                 try

--- a/src/CreateSpawn/Plugin.cs
+++ b/src/CreateSpawn/Plugin.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using LazyAPI;
 using Terraria;
+using Terraria.WorldBuilding;
 using TerrariaApi.Server;
 using TShockAPI;
 
@@ -16,13 +17,16 @@ public class CreateSpawn(Main game) : LazyPlugin(game)
     public override Version Version => new (1, 0, 1, 1);
 
     public override string Description => "使用指令复制区域建筑,支持保存建筑文件、跨地图粘贴";
+    
+    private bool _isCreatingWorld;
 
-    public bool IsNewWorld;
+    private bool _pendingSpawnAfterReset;
 
     public override void Initialize()
     {
         ServerApi.Hooks.GamePostInitialize.Register(this, this.GamePost);
-        On.Terraria.WorldBuilding.GenerationProgress.End += this.GenerationProgress_End;
+        On.Terraria.WorldGen.CreateNewWorld += this.WorldGen_CreateNewWorld;
+        On.Terraria.IO.WorldFile.LoadWorld += this.WorldFile_LoadWorld;
     }
 
     protected override void Dispose(bool disposing)
@@ -30,26 +34,53 @@ public class CreateSpawn(Main game) : LazyPlugin(game)
         if (disposing)
         {
             ServerApi.Hooks.GamePostInitialize.Deregister(this, this.GamePost);
-            On.Terraria.WorldBuilding.GenerationProgress.End -= this.GenerationProgress_End;
+            On.Terraria.WorldGen.CreateNewWorld -= this.WorldGen_CreateNewWorld;
+            On.Terraria.IO.WorldFile.LoadWorld -= this.WorldFile_LoadWorld;
         }
 
         base.Dispose(disposing);
     }
+    
 
-    private void GenerationProgress_End(On.Terraria.WorldBuilding.GenerationProgress.orig_End orig, Terraria.WorldBuilding.GenerationProgress self)
+    private Task WorldGen_CreateNewWorld(On.Terraria.WorldGen.orig_CreateNewWorld orig, GenerationProgress? progress, WorldGenerator.Controller? controller, WorldGen.WorldGenerationFinishCallback? afterGeneration)
     {
-        orig(self);
-        this.IsNewWorld = true;
+        this._isCreatingWorld = true;
+        return orig(progress, controller, afterGeneration);
+    }
+
+    private void WorldFile_LoadWorld(On.Terraria.IO.WorldFile.orig_LoadWorld orig)
+    {
+        orig();
+        if (!this._isCreatingWorld)
+        {
+            return;
+        }
+
+        this._isCreatingWorld = false;
+        this._pendingSpawnAfterReset = true;
+        this.TryAutoSpawn();
     }
 
 
     private void GamePost(EventArgs args)
     {
-        if (this.IsNewWorld)
+        if (this._pendingSpawnAfterReset)
+        {
+            this.TryAutoSpawn();
+        }
+    }
+
+    private void TryAutoSpawn()
+    {
+        if (!this._pendingSpawnAfterReset)
+        {
+            return;
+        }
+
+        try
         {
             if (Config.Instance.AutoSpawnBuilds.Count == 0)
             {
-                this.IsNewWorld = false;
                 return;
             }
 
@@ -57,7 +88,6 @@ public class CreateSpawn(Main game) : LazyPlugin(game)
             var spwy = Main.spawnTileY;
             var startX = spwx - Config.Instance.CentreX + Config.Instance.AdjustX;
             var startY = spwy - Config.Instance.CountY + Config.Instance.AdjustY;
-
             foreach (var name in Config.Instance.AutoSpawnBuilds.Distinct(StringComparer.OrdinalIgnoreCase))
             {
                 var clip = Map.LoadClip(name);
@@ -69,8 +99,10 @@ public class CreateSpawn(Main game) : LazyPlugin(game)
 
                 Utils.SpawnBuilding(TSPlayer.Server, startX, startY, clip);
             }
-
-            this.IsNewWorld = false;
+        }
+        finally
+        {
+            this._pendingSpawnAfterReset = false;
         }
     }
 }

--- a/src/CreateSpawn/Plugin.cs
+++ b/src/CreateSpawn/Plugin.cs
@@ -1,0 +1,76 @@
+﻿using System.Reflection;
+using LazyAPI;
+using Terraria;
+using TerrariaApi.Server;
+using TShockAPI;
+
+namespace CreateSpawn;
+
+[ApiVersion(2, 1)]
+public class CreateSpawn(Main game) : LazyPlugin(game)
+{
+    public override string Name => Assembly.GetExecutingAssembly().GetName().Name!;
+
+    public override string Author => "少司命 羽学 Eustia";
+
+    public override Version Version => new (1, 0, 1, 1);
+
+    public override string Description => "使用指令复制区域建筑,支持保存建筑文件、跨地图粘贴";
+
+    public bool IsNewWorld;
+
+    public override void Initialize()
+    {
+        ServerApi.Hooks.GamePostInitialize.Register(this, this.GamePost);
+        On.Terraria.WorldBuilding.GenerationProgress.End += this.GenerationProgress_End;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            ServerApi.Hooks.GamePostInitialize.Deregister(this, this.GamePost);
+            On.Terraria.WorldBuilding.GenerationProgress.End -= this.GenerationProgress_End;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private void GenerationProgress_End(On.Terraria.WorldBuilding.GenerationProgress.orig_End orig, Terraria.WorldBuilding.GenerationProgress self)
+    {
+        orig(self);
+        this.IsNewWorld = true;
+    }
+
+
+    private void GamePost(EventArgs args)
+    {
+        if (this.IsNewWorld)
+        {
+            if (Config.Instance.AutoSpawnBuilds.Count == 0)
+            {
+                this.IsNewWorld = false;
+                return;
+            }
+
+            var spwx = Main.spawnTileX;
+            var spwy = Main.spawnTileY;
+            var startX = spwx - Config.Instance.CentreX + Config.Instance.AdjustX;
+            var startY = spwy - Config.Instance.CountY + Config.Instance.AdjustY;
+
+            foreach (var name in Config.Instance.AutoSpawnBuilds.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                var clip = Map.LoadClip(name);
+                if (clip == null)
+                {
+                    TShock.Utils.Broadcast($"未找到名为 {name} 的建筑!", 240, 250, 150);
+                    continue;
+                }
+
+                Utils.SpawnBuilding(TSPlayer.Server, startX, startY, clip);
+            }
+
+            this.IsNewWorld = false;
+        }
+    }
+}

--- a/src/CreateSpawn/README.en-US.md
+++ b/src/CreateSpawn/README.en-US.md
@@ -1,0 +1,49 @@
+# CreateSpawn
+
+- author: 少司命
+- source: none
+- Spawn your copied building at the spawn point when creating the map
+
+## Commands
+
+| Command                |    Permission     |           Description           |
+|------------------------|:-----------------:|:-------------------------------:|
+| /cb set 1              | create.build.copy |     Select top-left corner      |
+| /cb set 2              | create.build.copy |   Select bottom-right corner    |
+| /cb save [name]        | create.build.copy |      Save a building clip       |
+| /cb spawn [name]       | create.build.copy |        Spawn a building         |
+| /cb back               | create.build.copy |      Restore covered tiles      |
+| /cb list               | create.build.copy |      List saved buildings       |
+| /cb zip                | create.build.copy | Backup and clear building files |
+| /cb auto add [name]    | create.build.copy |  Add build to auto-spawn list   |
+| /cb auto remove [name] | create.build.copy |   Remove from auto-spawn list   |
+| /cb auto list          | create.build.copy |      Show auto-spawn list       |
+| /cb auto clear         | create.build.copy |      Clear auto-spawn list      |
+
+## Configuration
+
+> Configuration file location: tshock/CreateSpawn.json
+
+```json5
+{
+  "CentreX": 0,
+  "CountY": 0,
+  "AdjustX": -21,
+  "AdjustY": 50,
+  "AutoSpawnBuilds": [
+    "Spawn",
+    "Lobby"
+  ]
+}
+```
+
+Notes:
+
+- The plugin no longer ships with an embedded default building.
+- New-world auto-spawn only uses names listed in `AutoSpawnBuilds`.
+
+## Feedback
+
+- Github Issue -> TShockPlugin Repo: https://github.com/UnrealMultiple/TShockPlugin
+- TShock QQ Group: 816771079
+- China Terraria Forum: trhub.cn, bbstr.net, tr.monika.love

--- a/src/CreateSpawn/README.md
+++ b/src/CreateSpawn/README.md
@@ -1,0 +1,107 @@
+# CreateSpawn 复制建筑
+
+- 作者: 少司命 羽学 Eustia
+- 出处: 本仓库
+- 这是一个Tshock服务器插件，主要用于：创建地图时使你的新地图支持复制建筑，使用指令在头顶生成建筑，不再固定为出生点
+
+## 指令
+
+| 语法                   |        权限         |      说明       |
+|----------------------|:-----------------:|:-------------:|
+| /cb set 1            | create.build.copy | 敲击或放置一个方块到左上角 |
+| /cb set 2            | create.build.copy | 敲击或放置一个方块到右下角 |
+| /cb save [名字]        | create.build.copy |     保存建筑      |
+| /cb spawn [名字]       | create.build.copy |     生成建筑      |
+| /cb back             | create.build.copy |   还原建筑覆盖图格    |
+| /cb list             | create.build.copy |    列出已有建筑     |
+| /cb zip              | create.build.copy |  清空建筑并备份为zip  |
+| /cb auto add [名字]    | create.build.copy | 添加到新世界自动生成列表  |
+| /cb auto remove [名字] | create.build.copy |   从自动生成列表移除   |
+| /cb auto list        | create.build.copy |   查看自动生成列表    |
+| /cb auto clear       | create.build.copy |   清空自动生成列表    |
+
+## 配置
+
+> 配置文件位置：tshock/CreateSpawn.json
+
+```json5
+{
+  "中心X": 0,
+  "计数Y": 0,
+  "微调X": -21,
+  "微调Y": 50,
+  "自动生成建筑": [
+    "出生点",
+    "大厅"
+  ]
+}
+```
+
+说明：
+
+- 本插件不再内置默认建筑文件，也不会自动创建 `DefaultBuild`。
+- 新世界自动生成仅对“自动生成建筑”列表中的建筑生效。
+
+## 更新日志
+
+### v1.0.1.1
+
+- 适配 TShock 6.1.0 / Terraria 1.4.5.x
+
+### v1.0.1.0
+
+- 加入了复制物品框、逻辑感应器、盘子、武器架、帽架、人体模特等家具时的物品还原
+
+### v1.0.0.9
+
+- 修复复制一次建筑，导致该晶塔即使挖掉也无法放置的BUG
+- 还原建筑时不再残留实体在图格上
+- 移除修复晶塔配置项
+
+### v1.0.0.8
+
+- 重构了/cb back还原指令方法
+- 修复还原指令能和生成建筑指令一样还原箱子物品与标牌消息
+
+### v1.0.0.7
+
+- Nuget包采用为Tshock 5.2.4
+- 重构代码逻辑，实现跨服复制建筑
+- 启动服务器时：未检测到CreateSpawn文件夹时则自动创建，并生成一个内嵌的“出生点_cp.map”文件
+- 在生成新地图时，自动会按名字为“出生点”建筑重建
+- 重构/cb spawn指令：
+- 当控制台使用`/cb sp 出生点`会以出生点为坐标进行生成(可通过配置文件调整),控制台使用/cb bk可撤销此建筑
+- 玩家使用`/cb sp 出生点`则以玩家头顶生成该建筑
+- 加入了/cb list指令：可列出所有可用的建筑名单
+- 加入了/cb zip指令：清空建筑文件并备份为zip
+- 修复了粘贴建筑时，无法复制箱子内物品与标牌内容信息的BUG
+- 加入了“修复晶塔”配置项，不推荐打开，使用/cb bk撤销时会留个晶塔传送图标在地图上
+- 使用了GZipStream极大降低了对建筑文件的空间占用
+
+### v1.0.0.6
+
+- Nuget包采用为TShock 5.2.2
+- 羽学内测版（此版本不依赖LazyAPI）：
+- 插件更名为《复制建筑》
+- 根据使用指令在头顶生成建筑，不再固定为出生点
+- 将/create指令更名为/cb spawn
+- 加入了/cb back指令，可还原建筑覆盖区域
+- 注意：本插件需要在新地图时才会生效，请删除tshock文件夹下对应的CreateSpawn.map文件再放入新地图
+
+### v1.0.0.3
+
+- 使用lazyapi
+
+### v1.0.0.2
+
+- i18n预定
+
+### v1.0.0.1
+
+- 补全卸载函数
+
+## 反馈
+
+- 优先发issued -> 共同维护的插件库：https://github.com/UnrealMultiple/TShockPlugin
+- 次优先：TShock官方群：816771079
+- 大概率看不到但是也可以：国内社区trhub.cn ，bbstr.net , tr.monika.love

--- a/src/CreateSpawn/TileHelper.cs
+++ b/src/CreateSpawn/TileHelper.cs
@@ -38,22 +38,18 @@ internal class TileHelper
 
     public static void InformPlayers()
     {
-        var players = TShock.Players;
-        foreach (var tSPlayer in players)
+        for (var j = 0; j < 255; j++)
         {
-            if (tSPlayer == null || !tSPlayer.Active)
+            if (!Netplay.Clients[j].IsActive)
             {
                 continue;
             }
 
-            for (var j = 0; j < 255; j++)
+            for (var k = 0; k < Main.maxSectionsX; k++)
             {
-                for (var k = 0; k < Main.maxSectionsX; k++)
+                for (var l = 0; l < Main.maxSectionsY; l++)
                 {
-                    for (var l = 0; l < Main.maxSectionsY; l++)
-                    {
-                        Netplay.Clients[j].TileSections[k, l] = false;
-                    }
+                    Netplay.Clients[j].TileSections[k, l] = false;
                 }
             }
         }

--- a/src/CreateSpawn/TileHelper.cs
+++ b/src/CreateSpawn/TileHelper.cs
@@ -1,0 +1,67 @@
+﻿using Terraria;
+using Terraria.ID;
+using TShockAPI;
+
+namespace CreateSpawn;
+
+internal class TileHelper
+{
+    public static bool IsTaskRunning { get; set; }
+
+    public static void StartGen()
+    {
+        IsTaskRunning = true;
+    }
+
+    public static void FinishGen()
+    {
+        IsTaskRunning = false;
+        TShock.Utils.SaveWorld();
+    }
+
+    public static bool NeedWaitTask(TSPlayer op)
+    {
+        if (IsTaskRunning)
+        {
+            op?.SendErrorMessage(GetString("另一个创建任务正在执行，请稍后再操作"));
+        }
+
+        return IsTaskRunning;
+    }
+
+    public static void ClearEverything(int x, int y)
+    {
+        Main.tile[x, y].ClearEverything();
+        NetMessage.SendTileSquare(-1, x, y, TileChangeType.None);
+    }
+
+
+    public static void InformPlayers()
+    {
+        var players = TShock.Players;
+        foreach (var tSPlayer in players)
+        {
+            if (tSPlayer == null || !tSPlayer.Active)
+            {
+                continue;
+            }
+
+            for (var j = 0; j < 255; j++)
+            {
+                for (var k = 0; k < Main.maxSectionsX; k++)
+                {
+                    for (var l = 0; l < Main.maxSectionsY; l++)
+                    {
+                        Netplay.Clients[j].TileSections[k, l] = false;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void GenAfter()
+    {
+        InformPlayers();
+        FinishGen();
+    }
+}

--- a/src/CreateSpawn/Utils.cs
+++ b/src/CreateSpawn/Utils.cs
@@ -1,0 +1,988 @@
+﻿using Microsoft.Xna.Framework;
+using Terraria;
+using Terraria.DataStructures;
+using Terraria.GameContent.Tile_Entities;
+using Terraria.ID;
+using TShockAPI;
+
+namespace CreateSpawn;
+
+internal static class Utils
+{
+    private static bool TryGetChestTopLeft(int x, int y, out int chestX, out int chestY)
+    {
+        chestX = x;
+        chestY = y;
+        var tile = Main.tile[x, y];
+        if (tile == null || !tile.active() || !TileID.Sets.BasicChest[tile.type])
+        {
+            return false;
+        }
+
+        chestX = x - (tile.frameX / 18 % 2);
+        chestY = y - (tile.frameY / 18);
+        return true;
+    }
+
+    public static void SaveOrigTile(TSPlayer plr, int startX, int startY, int endX, int endY)
+    {
+        // 使用CopyBuilding方法创建当前选区的原始建筑数据
+        var building = CopyBuilding(startX, startY, endX, endY);
+
+        // 将building对象压入栈中
+        var stack = Map.LoadBack(plr.Name);
+        stack.Push(building);
+        Map.SaveBack(plr.Name, stack);
+    }
+
+    public static void RollbackBuilding(TSPlayer plr)
+    {
+        var stack = Map.LoadBack(plr.Name);
+        if (stack.Count == 0)
+        {
+            plr.SendErrorMessage(GetString("没有可还原的图格"));
+            return;
+        }
+
+        var building = stack.Pop();
+        Map.SaveBack(plr.Name, stack);
+
+        // 计算选区边界
+        var startX = building.Origin.X;
+        var startY = building.Origin.Y;
+        var endX = startX + building.Width - 1;
+        var endY = startY + building.Height - 1;
+
+        if (building.Tiles == null)
+        {
+            return;
+        }
+
+        // 0. 还原前先销毁当前区域的互动家具实体
+        KillAll(startX, endX, startY, endY);
+
+        // 1. 还原图格数据
+        for (var x = 0; x < building.Width; x++)
+        {
+            for (var y = 0; y < building.Height; y++)
+            {
+                var worldX = startX + x;
+                var worldY = startY + y;
+
+                if (worldX < 0 || worldX >= Main.maxTilesX ||
+                    worldY < 0 || worldY >= Main.maxTilesY)
+                {
+                    continue;
+                }
+
+                Main.tile[worldX, worldY].CopyFrom(building.Tiles[x, y]);
+                TSPlayer.All.SendTileSquareCentered(worldX, worldY, 1);
+            }
+        }
+
+        // 2. 修复实体
+        FixAll(startX, endX, startY, endY);
+
+        // 3. 恢复箱子物品（依赖已存在的箱子实体）
+        if (building.ChestItems != null)
+        {
+            RestoreChestItems(building.ChestItems, new Point(0, 0));
+        }
+
+        // 4. 恢复标牌信息
+        RestoreSignText(building, 0, 0);
+
+        // 5. 物品框、盘子、武器架、人偶、衣帽架
+        RestoreItemFrames(building.ItemFrames, new Point(0, 0));
+        RestorefoodPlatter(building.FoodPlatters, new Point(0, 0));
+        RestoreWeaponsRack(building.WeaponsRacks, new Point(0, 0));
+        RestoreDisplayDoll(building.DisplayDolls, new Point(0, 0));
+        RestoreHatRack(building.HatRacks, new Point(0, 0));
+        RestoreLogicSensor(building.LogicSensors, new Point(0, 0));
+    }
+
+    public static Building CopyBuilding(int startX, int startY, int endX, int endY)
+    {
+        var minX = Math.Min(startX, endX);
+        var maxX = Math.Max(startX, endX);
+        var minY = Math.Min(startY, endY);
+        var maxY = Math.Max(startY, endY);
+
+        var width = maxX - minX + 1;
+        var height = maxY - minY + 1;
+
+        var tiles = new Tile[width, height];
+
+        var chestItems = new List<ChestItems>(); // 定义箱子物品及其位置
+        var signText = new List<Sign>(); // 用于存储标牌数据
+        var itemFrames = new List<ItemFrames>(); // 用于存储物品框数据
+        var weaponsRack = new List<WeaponRack>(); //武器架物品
+        var foodPlatter = new List<FPlatters>(); //盘子物品
+        var displayDolls = new List<DDolls>(); //人偶物品
+        var hatRacks = new List<HatRacks>(); //衣帽架物品
+        var logicSensor = new List<LogicSensors>(); //逻辑感应器
+        for (var x = minX; x <= maxX; x++)
+        {
+            for (var y = minY; y <= maxY; y++)
+            {
+                var indexX = x - minX;
+                var indexY = y - minY;
+
+                //复制图格
+                tiles[indexX, indexY] = (Tile) Main.tile[x, y].Clone();
+
+                GetChestItems(chestItems, x, y); //获取箱子物品
+                GetSign(signText, x, y); //获取标牌、广播盒、墓碑上等可阅读家具的信息
+                GetItemFrames(itemFrames, x, y); //获取物品框的物品
+                GetWeaponsRack(weaponsRack, x, y); //获取武器架的物品
+                GetfoodPlatter(foodPlatter, x, y); //获取盘子的物品
+                GetDisplayDoll(displayDolls, x, y); //获取人偶的物品
+                GetHatRack(hatRacks, x, y); //获取衣帽架物品
+                GetLogicSensor(logicSensor, x, y); //获取逻辑感应器开关状态
+            }
+        }
+
+        return new Building
+        {
+            Width = width,
+            Height = height,
+            Tiles = tiles,
+            Origin = new Point(minX, minY),
+            ChestItems = chestItems,
+            Signs = signText,
+            ItemFrames = itemFrames,
+            WeaponsRacks = weaponsRack,
+            FoodPlatters = foodPlatter,
+            DisplayDolls = displayDolls,
+            HatRacks = hatRacks,
+            LogicSensors = logicSensor
+        };
+    }
+
+    public static void GetChestItems(List<ChestItems> chestItems, int x, int y)
+    {
+        // 判断是否是箱子图格
+        if (!TileID.Sets.BasicChest[Main.tile[x, y].type])
+        {
+            return;
+        }
+
+        // 查找对应的 Chest 对象
+        var index = Chest.FindChest(x, y);
+        if (index < 0)
+        {
+            return;
+        }
+
+        var chest = Main.chest[index];
+        if (chest == null)
+        {
+            return;
+        }
+
+        // 只处理箱子的左上角图格
+        if (x != chest.x || y != chest.y)
+        {
+            return;
+        }
+
+        //定义箱子内的物品格子位置
+        for (var slot = 0; slot < 40; slot++)
+        {
+            var item = chest.item[slot];
+            if (item?.active == true)
+            {
+                // 克隆物品并记录其原来所在箱子的位置
+                chestItems.Add(new ChestItems
+                {
+                    Item = item.Clone(), // 克隆物品
+                    Position = new Point(x, y), // 记录箱子位置
+                    Slot = slot
+                });
+            }
+        }
+    }
+
+    public static void RestoreChestItems(IEnumerable<ChestItems> Chests, Point offset)
+    {
+        if (Chests == null || !Chests.Any())
+        {
+            return;
+        }
+
+        foreach (var data in Chests)
+        {
+            try
+            {
+                if (data.Item == null || data.Item.IsAir)
+                {
+                    continue;
+                }
+
+                // 计算新的箱子位置
+                var newX = data.Position.X + offset.X;
+                var newY = data.Position.Y + offset.Y;
+
+                // 查找箱子
+                var index = Chest.FindChest(newX, newY);
+                if (index == -1)
+                {
+                    continue;
+                }
+
+                //获取箱子对象
+                var chest = Main.chest[index];
+
+                // 检查槽位是否合法
+                if (data.Slot < 0 || data.Slot >= 40)
+                {
+                    continue;
+                }
+
+                // 克隆物品并设置到箱子槽位
+                chest.item[data.Slot] = (Item) data.Item.Clone();
+            }
+            catch (Exception ex)
+            {
+                TShock.Log.ConsoleError(GetString($"还原箱子物品出错 @ {data.Position}: {ex}"));
+            }
+        }
+    }
+
+    public static void GetSign(List<Sign> signs, int x, int y)
+    {
+        if (Main.tile[x, y]?.active() == true && Main.tileSign[Main.tile[x, y].type])
+        {
+            // 获取 Sign ID
+            var signId = Sign.ReadSign(x, y);
+            if (signId >= 0)
+            {
+                var origSign = Main.sign[signId];
+                if (origSign != null)
+                {
+                    signs.Add(new Sign { x = x, y = y, text = origSign.text ?? "" });
+                }
+            }
+        }
+    }
+
+    private static int CreateNewSign(int x, int y)
+    {
+        // 查找是否有重复的 Sign
+        for (var i = 0; i < Sign.maxSigns; i++)
+        {
+            if (Main.sign[i] != null && Main.sign[i].x == x && Main.sign[i].y == y)
+            {
+                return i;
+            }
+        }
+
+        // 找一个空槽位插入新的 Sign
+        for (var i = 0; i < Sign.maxSigns; i++)
+        {
+            if (Main.sign[i] == null)
+            {
+                Main.sign[i] = new Sign { x = x, y = y, text = "" };
+                return i;
+            }
+        }
+
+        return -1; // 没有可用槽位
+    }
+
+    public static void RestoreSignText(Building clip, int baseX, int baseY)
+    {
+        if (clip.Signs != null)
+        {
+            foreach (var sign in clip.Signs)
+            {
+                var newX = sign.x + baseX;
+                var newY = sign.y + baseY;
+
+                if (newX < 0 || newY < 0 || newX >= Main.maxTilesX || newY >= Main.maxTilesY)
+                {
+                    continue;
+                }
+
+                var tile = Main.tile[newX, newY];
+                if (tile == null || !tile.active() || !Main.tileSign[tile.type])
+                {
+                    continue;
+                }
+
+                // 创建新的 Sign 或复用已有的
+                var signId = CreateNewSign(newX, newY);
+                if (signId >= 0)
+                {
+                    Main.sign[signId].text = sign.text;
+                }
+            }
+        }
+    }
+
+    public static void GetItemFrames(List<ItemFrames> itemFrames, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.type != TileID.ItemFrame)
+        {
+            return;
+        }
+
+        if (tile.frameX % 36 != 0 || tile.frameY != 0)
+        {
+            return;
+        }
+
+        var id = TEItemFrame.Find(x, y);
+        if (id != -1)
+        {
+            var frame = (TEItemFrame) TileEntity.ByID[id];
+            itemFrames.Add(new ItemFrames { Item = new NetItem(frame.item.type, frame.item.stack, frame.item.prefix), Position = new Point(x, y) });
+        }
+    }
+
+    public static void RestoreItemFrames(List<ItemFrames> itemFrames, Point offset)
+    {
+        if (itemFrames == null || !itemFrames.Any())
+        {
+            return;
+        }
+
+        foreach (var data in itemFrames)
+        {
+            // 计算新的物品框位置
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            // 获取图格信息
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() || tile.type != TileID.ItemFrame)
+            {
+                continue;
+            }
+
+            // 查找或创建 TEItemFrame（TileEntity）
+            var id = TEItemFrame.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TEItemFrame.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            // 获取物品框实体
+            var frame = (TEItemFrame) TileEntity.ByID[id];
+
+            // 创建一个实际的物品对象并复制数据
+            var item = new Item();
+            item.netDefaults(data.Item.NetId); // 设置物品 ID
+            item.stack = data.Item.Stack; // 设置数量
+            item.prefix = data.Item.PrefixId; // 设置前缀
+
+            // 更新物品框内的物品
+            frame.item = item;
+        }
+    }
+
+    public static void GetWeaponsRack(List<WeaponRack> WRack, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.frameX % 54 != 0 || tile.frameY != 0)
+        {
+            return;
+        }
+
+        if (tile.type == TileID.WeaponsRack2)
+        {
+            var id = TEWeaponsRack.Find(x, y);
+            if (id != -1)
+            {
+                var rack = (TEWeaponsRack) TileEntity.ByID[id];
+                WRack.Add(new WeaponRack { Item = new NetItem(rack.item.type, rack.item.stack, rack.item.prefix), Position = new Point(x, y) });
+            }
+        }
+    }
+
+    public static void RestoreWeaponsRack(List<WeaponRack> WRack, Point offset)
+    {
+        if (WRack == null || !WRack.Any())
+        {
+            return;
+        }
+
+        foreach (var data in WRack)
+        {
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() || tile.type != TileID.WeaponsRack2)
+            {
+                continue;
+            }
+
+            var id = TEWeaponsRack.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TEWeaponsRack.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            var rack = (TEWeaponsRack) TileEntity.ByID[id];
+
+            // 创建一个实际的物品对象并复制数据
+            var item = new Item();
+            item.netDefaults(data.Item.NetId); // 设置物品 ID
+            item.stack = data.Item.Stack; // 设置数量
+            item.prefix = data.Item.PrefixId; // 设置前缀
+
+            rack.item = item;
+        }
+    }
+
+    public static void GetfoodPlatter(List<FPlatters> FPlatter, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.type == TileID.FoodPlatter)
+        {
+            var id = TEFoodPlatter.Find(x, y);
+            if (id != -1)
+            {
+                var platter = (TEFoodPlatter) TileEntity.ByID[id];
+                FPlatter.Add(new FPlatters { Item = new NetItem(platter.item.type, platter.item.stack, platter.item.prefix), Position = new Point(x, y) });
+            }
+        }
+    }
+
+    public static void RestorefoodPlatter(List<FPlatters> FPlatter, Point offset)
+    {
+        if (FPlatter == null || FPlatter.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var data in FPlatter)
+        {
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() ||
+                tile.type != TileID.FoodPlatter)
+            {
+                continue;
+            }
+
+            var id = TEFoodPlatter.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TEFoodPlatter.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            var food = (TEFoodPlatter) TileEntity.ByID[id];
+            // 创建一个实际的物品对象并复制数据
+            var item = new Item();
+            item.netDefaults(data.Item.NetId); // 设置物品 ID
+            item.stack = data.Item.Stack; // 设置数量
+            item.prefix = data.Item.PrefixId; // 设置前缀
+
+            food.item = item;
+        }
+    }
+
+    public static void GetDisplayDoll(List<DDolls> Dolls, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.type == TileID.DisplayDoll)
+        {
+            var id = TEDisplayDoll.Find(x, y);
+            if (id != -1)
+            {
+                var doll = (TEDisplayDoll) TileEntity.ByID[id];
+                Dolls.Add(new DDolls { Items = doll._equip.Select(i => new NetItem(i.type, i.stack, i.prefix)).ToArray(), Dyes = doll._dyes.Select(i => new NetItem(i.type, i.stack, i.prefix)).ToArray(), Position = new Point(x, y) });
+            }
+        }
+    }
+
+    public static void RestoreDisplayDoll(List<DDolls> Dolls, Point offset)
+    {
+        if (Dolls == null || !Dolls.Any())
+        {
+            return;
+        }
+
+        foreach (var data in Dolls)
+        {
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() ||
+                tile.type != TileID.DisplayDoll)
+            {
+                continue;
+            }
+
+            var id = TEDisplayDoll.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TEDisplayDoll.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            var doll = (TEDisplayDoll) TileEntity.ByID[id];
+            doll._equip = new Item[data.Items.Length];
+            for (var i = 0; i < data.Items.Length; i++)
+            {
+                var netItem = data.Items[i];
+                var item = new Item();
+                item.netDefaults(netItem.NetId);
+                item.stack = netItem.Stack;
+                item.prefix = netItem.PrefixId;
+                doll._equip[i] = item;
+            }
+
+            doll._dyes = new Item[data.Dyes.Length];
+            for (var i = 0; i < data.Dyes.Length; i++)
+            {
+                var netItem = data.Dyes[i];
+                var item = new Item();
+                item.netDefaults(netItem.NetId);
+                item.stack = netItem.Stack;
+                item.prefix = netItem.PrefixId;
+                doll._dyes[i] = item;
+            }
+        }
+    }
+
+    public static void GetHatRack(List<HatRacks> Racks, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.type == TileID.HatRack)
+        {
+            var id = TEHatRack.Find(x, y);
+            if (id != -1)
+            {
+                var doll = (TEHatRack) TileEntity.ByID[id];
+                Racks.Add(new HatRacks { Items = doll._items.Select(i => new NetItem(i.type, i.stack, i.prefix)).ToArray(), Dyes = doll._dyes.Select(i => new NetItem(i.type, i.stack, i.prefix)).ToArray(), Position = new Point(x, y) });
+            }
+        }
+    }
+
+    public static void RestoreHatRack(List<HatRacks> Racks, Point offset)
+    {
+        if (Racks == null || !Racks.Any())
+        {
+            return;
+        }
+
+        foreach (var data in Racks)
+        {
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() ||
+                tile.type != TileID.HatRack)
+            {
+                continue;
+            }
+
+            var id = TEHatRack.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TEHatRack.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            var Rack = (TEHatRack) TileEntity.ByID[id];
+            Rack._items = new Item[data.Items.Length];
+            for (var i = 0; i < data.Items.Length; i++)
+            {
+                var netItem = data.Items[i];
+                var item = new Item();
+                item.netDefaults(netItem.NetId);
+                item.stack = netItem.Stack;
+                item.prefix = netItem.PrefixId;
+                Rack._items[i] = item;
+            }
+
+            Rack._dyes = new Item[data.Dyes.Length];
+            for (var i = 0; i < data.Dyes.Length; i++)
+            {
+                var netItem = data.Dyes[i];
+                var item = new Item();
+                item.netDefaults(netItem.NetId);
+                item.stack = netItem.Stack;
+                item.prefix = netItem.PrefixId;
+                Rack._dyes[i] = item;
+            }
+        }
+    }
+
+    public static void GetLogicSensor(List<LogicSensors> sensors, int x, int y)
+    {
+        var tile = Main.tile[x, y];
+        if (tile.type == TileID.LogicSensor)
+        {
+            var id = TELogicSensor.Find(x, y);
+            if (id != -1)
+            {
+                var sensor = (TELogicSensor) TileEntity.ByID[id];
+                sensors.Add(new LogicSensors { type = sensor.logicCheck, Position = new Point(x, y) });
+            }
+        }
+    }
+
+    public static void RestoreLogicSensor(List<LogicSensors> Sensors, Point offset)
+    {
+        if (Sensors == null || !Sensors.Any())
+        {
+            return;
+        }
+
+        foreach (var data in Sensors)
+        {
+            var newX = data.Position.X + offset.X;
+            var newY = data.Position.Y + offset.Y;
+
+            var tile = Main.tile[newX, newY];
+            if (tile == null || !tile.active() ||
+                tile.type != TileID.LogicSensor)
+            {
+                continue;
+            }
+
+            var id = TELogicSensor.Find(newX, newY);
+            if (id == -1)
+            {
+                id = TELogicSensor.Place(newX, newY);
+                if (id == -1)
+                {
+                    continue; // 创建失败
+                }
+            }
+
+            var Sensor = (TELogicSensor) TileEntity.ByID[id];
+            Sensor.logicCheck = data.type;
+        }
+    }
+
+    public static void FixAll(int startX, int endX, int startY, int endY)
+    {
+        for (var x = startX; x <= endX; x++)
+        {
+            for (var y = startY; y <= endY; y++)
+            {
+                var tile = Main.tile[x, y];
+                if (tile == null || !tile.active())
+                {
+                    continue;
+                }
+
+                //如果查找图格里是箱子
+                if (TryGetChestTopLeft(x, y, out var chestX, out var chestY) && (x != chestX || y != chestY))
+                {
+                    continue;
+                }
+
+                if (TryGetChestTopLeft(x, y, out chestX, out chestY) && Chest.FindChest(chestX, chestY) == -1)
+                {
+                    var newChest = Chest.CreateChest(chestX, chestY);
+                    if (newChest == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                // 同步箱子图格到主位置
+                if (tile.type == TileID.Containers || tile.type == TileID.Containers2)
+                {
+                    WorldGen.SquareTileFrame(x, y, true);
+                }
+
+                //物品框
+                if (tile.type == TileID.ItemFrame && tile.frameX % 36 == 0 && tile.frameY == 0)
+                {
+                    var ItemFrame = TEItemFrame.Place(x, y);
+                    WorldGen.SquareTileFrame(x, y, true);
+                    if (ItemFrame == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //武器架
+                if ((tile.type == TileID.WeaponsRack || tile.type == TileID.WeaponsRack2) && tile.frameX % 54 == 0 && tile.frameY == 0)
+                {
+                    var WeaponsRack = TEWeaponsRack.Place(x, y);
+                    WorldGen.SquareTileFrame(x, y, true);
+                    if (WeaponsRack == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //标牌 墓碑  广播盒
+                if ((tile.type == TileID.Signs ||
+                     tile.type == TileID.Tombstones ||
+                     tile.type == TileID.AnnouncementBox) &&
+                    tile.frameX % 36 == 0 && tile.frameY == 0 &&
+                    Sign.ReadSign(x, y, false) == -1)
+                {
+                    var sign = Sign.ReadSign(x, y, true);
+                    if (sign == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //逻辑感应器
+                if (tile.type == TileID.LogicSensor && TELogicSensor.Find(x, y) == -1)
+                {
+                    var LogicSensor = TELogicSensor.Place(x, y);
+                    if (LogicSensor == -1)
+                    {
+                        continue;
+                    }
+
+                    ((TELogicSensor) TileEntity.ByID[LogicSensor]).logicCheck = (TELogicSensor.LogicCheckType) ((tile.frameY / 18) + 1);
+                }
+
+                //人体模型
+                if (tile.type == TileID.DisplayDoll && tile.frameX % 36 == 0 && tile.frameY == 0)
+                {
+                    var DisplayDoll = TEDisplayDoll.Place(x, y);
+                    if (DisplayDoll == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //盘子
+                if (tile.type == TileID.FoodPlatter)
+                {
+                    var FoodPlatter = TEFoodPlatter.Place(x, y);
+                    WorldGen.SquareTileFrame(x, y, true);
+                    if (FoodPlatter == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //晶塔
+                if (tile.type == TileID.TeleportationPylon && tile.frameX % 54 == 0 && tile.frameY == 0)
+                {
+                    var TeleportationPylon = TETeleportationPylon.Place(x, y);
+                    if (TeleportationPylon == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //训练假人（稻草人）
+                if (tile.type == TileID.TargetDummy && tile.frameX % 36 == 0 && tile.frameY == 0)
+                {
+                    var TrainingDummy = TETrainingDummy.Place(x, y);
+                    if (TrainingDummy == -1)
+                    {
+                        continue;
+                    }
+                }
+
+                //衣帽架
+                if (tile.type == TileID.HatRack && tile.frameX == 0 && tile.frameY == 0)
+                {
+                    var HatRack = TEHatRack.Place(x, y);
+                    WorldGen.SquareTileFrame(x, y, true);
+                    if (HatRack == -1)
+                    {
+                        continue;
+                    }
+                }
+            }
+        }
+    }
+
+    public static void KillAll(int startX, int endX, int startY, int endY)
+    {
+        for (var x = startX; x <= endX; x++)
+        {
+            for (var y = startY; y <= endY; y++)
+            {
+                var tile = Main.tile[x, y];
+                if (tile == null || !tile.active())
+                {
+                    continue;
+                }
+
+                //如果查找图格里是箱子
+                if (TryGetChestTopLeft(x, y, out var chestX, out var chestY) && (x != chestX || y != chestY))
+                {
+                    continue;
+                }
+
+                if (TryGetChestTopLeft(x, y, out chestX, out chestY) && Chest.FindChest(chestX, chestY) != -1)
+                {
+                    Chest.DestroyChest(chestX, chestY);
+                }
+
+                //物品框
+                if (tile.type == TileID.ItemFrame)
+                {
+                    TEItemFrame.Kill(x, y);
+                }
+
+                //武器架
+                if (tile.type == TileID.WeaponsRack || tile.type == TileID.WeaponsRack2)
+                {
+                    TEWeaponsRack.Kill(x, y);
+                }
+
+                //标牌 墓碑  广播盒
+                if (tile.type == TileID.Signs ||
+                    tile.type == TileID.Tombstones ||
+                    tile.type == TileID.AnnouncementBox)
+                {
+                    Sign.KillSign(x, y);
+                }
+
+                //逻辑感应器
+                if (tile.type == TileID.LogicSensor)
+                {
+                    TELogicSensor.Kill(x, y);
+                }
+
+                //人体模型
+                if (tile.type == TileID.DisplayDoll)
+                {
+                    TEDisplayDoll.Kill(x, y);
+                }
+
+                //盘子
+                if (tile.type == TileID.FoodPlatter)
+                {
+                    TEFoodPlatter.Kill(x, y);
+                }
+
+                //晶塔
+                if (tile.type == TileID.TeleportationPylon)
+                {
+                    TETeleportationPylon.Kill(x, y);
+                }
+
+                //训练假人（稻草人）
+                if (tile.type == TileID.TargetDummy)
+                {
+                    TETrainingDummy.Kill(x, y);
+                }
+
+                //衣帽架
+                if (tile.type == TileID.HatRack)
+                {
+                    TEHatRack.Kill(x, y);
+                }
+            }
+        }
+    }
+
+    public static void SpawnBuilding(TSPlayer plr, int startX, int startY, Building clip)
+    {
+        TileHelper.StartGen();
+        var secondLast = GetUnixTimestamp;
+        try
+        {
+            //缓存 方便粘贴错了还原
+            SaveOrigTile(plr, startX, startY, startX + clip.Width - 1, startY + clip.Height - 1);
+
+            // 定义偏移坐标（从原始世界坐标到玩家头顶）
+            var baseX = startX - clip.Origin.X;
+            var baseY = startY - clip.Origin.Y;
+
+            // 先销毁目标区域的互动家具实体
+            KillAll(startX, startX + clip.Width - 1, startY, startY + clip.Height - 1);
+
+            for (var x = 0; x < clip.Width; x++)
+            {
+                for (var y = 0; y < clip.Height; y++)
+                {
+                    var worldX = startX + x;
+                    var worldY = startY + y;
+
+                    // 边界检查
+                    if (worldX < 0 || worldX >= Main.maxTilesX ||
+                        worldY < 0 || worldY >= Main.maxTilesY)
+                    {
+                        continue;
+                    }
+
+                    // 完全复制图格数据
+                    Main.tile[worldX, worldY] = (Tile) clip.Tiles![x, y].Clone();
+                }
+            }
+
+            // 修复家具实体
+            FixAll(startX, startX + clip.Width - 1, startY, startY + clip.Height - 1);
+            // 修复箱子内物品
+            RestoreChestItems(clip.ChestItems!, new Point(baseX, baseY));
+            // 修复标牌信息
+            RestoreSignText(clip, baseX, baseY);
+            // 修复物品框物品
+            RestoreItemFrames(clip.ItemFrames, new Point(baseX, baseY));
+            //修复盘子、武器架、人偶、衣帽架的物品
+            RestorefoodPlatter(clip.FoodPlatters, new Point(baseX, baseY));
+            RestoreWeaponsRack(clip.WeaponsRacks, new Point(baseX, baseY));
+            RestoreDisplayDoll(clip.DisplayDolls, new Point(baseX, baseY));
+            RestoreHatRack(clip.HatRacks, new Point(baseX, baseY));
+            RestoreLogicSensor(clip.LogicSensors, new Point(baseX, baseY));
+            var value = GetUnixTimestamp - secondLast;
+            plr.SendSuccessMessage(GetString($"已粘贴区域 ({clip.Width} x {clip.Height})，用时{value}秒。"));
+        }
+        finally
+        {
+            TileHelper.GenAfter();
+        }
+    }
+
+    public static int GetUnixTimestamp => (int) DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+
+    public static void Restore(TSPlayer ply)
+    {
+        var startX = ply.TempPoints[0].X;
+        var startY = ply.TempPoints[0].Y;
+        var endX = ply.TempPoints[1].X;
+        var endY = ply.TempPoints[1].Y;
+        TileHelper.StartGen();
+        var secondLast = GetUnixTimestamp;
+        try
+        {
+            //还原前缓存一遍
+            SaveOrigTile(ply, startX, startY, endX, endY);
+
+            //还原方法
+            RollbackBuilding(ply);
+
+            var value = GetUnixTimestamp - secondLast;
+            ply.SendSuccessMessage(GetString($"已将选区还原，用时{value}秒。"));
+        }
+        finally
+        {
+            TileHelper.GenAfter();
+        }
+    }
+}

--- a/src/CreateSpawn/manifest.json
+++ b/src/CreateSpawn/manifest.json
@@ -1,0 +1,11 @@
+{
+  "README.en-US": {
+    "Description": "Spawn point building generation"
+  },
+  "README.es-ES": {
+    "Description": "Generación de puntos de aparición"
+  },
+  "README": {
+    "Description": "出生点建筑生成"
+  }
+}


### PR DESCRIPTION
### 添加插件
- [ √] 插件已加入解决方案 (Plugin.sln)
- [ √] 插件项目已导入template.targets (<Import Project="..\template.targets"/>)
- [ √] 插件信息已添加至对应manifest.json
- [ √] 插件的文件夹名字和插件的插件项目名字一样 (XXX/XXX.csproj)  
- [ √] 添加插件单独的README.md文件 (XXX/README.md)
- [ √] 插件可以正常工作
### 更新插件/修复BUG
- [ ] 插件已修改版本号
- [ ] 更新插件README.md中的更新日志
- [ ] 插件可以正常工作
### 其他
- [ ] ❤️熙恩我喜欢你

## Summary by Sourcery

添加一个新的 CreateSpawn 插件，使其在 Terraria/TShock 服务器上支持对建筑区域进行复制、保存、列出、恢复以及自动生成，并支持持久化与配置功能。

New Features:
- 引入 CreateSpawn 插件，提供用于选择、保存、生成（spawn）、列出和恢复已复制建筑区域的命令。
- 支持将已复制的建筑区域持久化到压缩的地图文件中，并可在不同世界或服务器之间加载这些区域。
- 基于配置，在新世界生成时自动生成预定义建筑。
- 为 CreateSpawn 插件提供本地化文档和清单（manifest）元数据。

Enhancements:
- 在复制、恢复和生成建筑时，对家具、箱子、告示牌、物品展示框、人形模特以及其他方块实体进行健壮的处理，以保留其内容和状态。
- 添加世界生成的钩子（hooks）和任务协同工具，用于安全地执行大规模建筑粘贴操作，避免与其他任务产生冲突。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new CreateSpawn plugin that enables copying, saving, listing, restoring, and auto-spawning of building regions on Terraria/TShock servers, including persistence and configuration support.

New Features:
- Introduce a CreateSpawn plugin with commands to select, save, spawn, list, and restore copied building areas.
- Support persistence of copied building regions to compressed map files and loading them across worlds or servers.
- Add configuration-driven automatic spawning of predefined buildings when a new world is generated.
- Provide localized documentation and manifest metadata for the CreateSpawn plugin.

Enhancements:
- Implement robust handling of furniture, chests, signs, item frames, mannequins, and other tile entities when copying, restoring, and spawning buildings to preserve their contents and state.
- Add world-generation hooks and task coordination utilities to safely run large building paste operations without conflicting tasks.

</details>